### PR TITLE
Feat: Implement High-Contrast Mode

### DIFF
--- a/src/components/ui/HighContrastToggle.tsx
+++ b/src/components/ui/HighContrastToggle.tsx
@@ -1,0 +1,20 @@
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useSettingsStore } from '@/stores/settingsStore'; // Adjust path if store is elsewhere
+
+export const HighContrastToggle = () => {
+  const isHighContrastMode = useSettingsStore((state) => state.isHighContrastMode);
+  const toggleHighContrastMode = useSettingsStore((state) => state.toggleHighContrastMode);
+
+  return (
+    <div className="flex items-center space-x-2 p-4">
+      <Switch
+        id="high-contrast-mode"
+        checked={isHighContrastMode}
+        onCheckedChange={toggleHighContrastMode}
+        aria-label="Toggle high contrast mode"
+      />
+      <Label htmlFor="high-contrast-mode">High Contrast Mode</Label>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -6,79 +6,71 @@
   :root {
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
-
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
-
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
-
-    --primary: 222.2 47.4% 11.2%;
+    --primary: 221.2 83.2% 53.3%; /* Updated Blue */
     --primary-foreground: 210 40% 98%;
-
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
-
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
-
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-
-    --destructive: 0 84.2% 60.2%;
+    --accent: 210 40% 96.1%; /* Assuming same as secondary for default */
+    --accent-foreground: 222.2 47.4% 11.2%; /* Assuming same as secondary-foreground for default */
+    --destructive: 0 84.2% 60.2%; /* Red */
     --destructive-foreground: 210 40% 98%;
-
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-
+    --ring: 221.2 83.2% 53.3%; /* Updated to primary blue */
     --radius: 0.5rem;
 
+    /* Custom PRD colors - Default Theme */
+    --success: 142.1 70.6% 45.3%; /* #10B981 Green */
+    --success-foreground: 210 40% 98%;
+    --warning: 38.9 92.3% 50.4%; /* #F59E0B Amber */
+    --warning-foreground: 222.2 84% 4.9%; /* Dark text for Amber */
+
+    /* Default Sidebar variables from original file (can be adjusted if needed) */
     --sidebar-background: 0 0% 98%;
-
     --sidebar-foreground: 240 5.3% 26.1%;
-
     --sidebar-primary: 240 5.9% 10%;
-
     --sidebar-primary-foreground: 0 0% 98%;
-
     --sidebar-accent: 240 4.8% 95.9%;
-
     --sidebar-accent-foreground: 240 5.9% 10%;
-
     --sidebar-border: 220 13% 91%;
-
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
 
   .dark {
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;
-
     --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;
-
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-
     --primary: 210 40% 98%;
     --primary-foreground: 222.2 47.4% 11.2%;
-
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
-
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
-
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
-
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
-
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
+
+    /* Custom PRD colors - Dark Theme (assuming they might need adjustment for dark mode) */
+    /* For now, let's use the same as default, but these could be different */
+    --success: 142.1 70.6% 45.3%;
+    --success-foreground: 210 40% 98%;
+    --warning: 38.9 92.3% 50.4%;
+    --warning-foreground: 222.2 84% 4.9%;
+
+    /* Dark Sidebar variables from original file */
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;
@@ -87,6 +79,44 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+  }
+
+  .theme-high-contrast {
+    --background: 0 0% 0%;              /* #000000 Black */
+    --foreground: 0 0% 100%;            /* #FFFFFF White */
+    --card: 0 0% 10.2%;                 /* #1A1A1A Dark Gray */
+    --card-foreground: 0 0% 100%;       /* #FFFFFF White */
+    --popover: 0 0% 10.2%;              /* #1A1A1A Dark Gray */
+    --popover-foreground: 0 0% 100%;    /* #FFFFFF White */
+    --primary: 60 100% 50%;             /* #FFFF00 Yellow */
+    --primary-foreground: 0 0% 0%;      /* #000000 Black */
+    --secondary: 180 100% 50%;          /* #00FFFF Cyan */
+    --secondary-foreground: 0 0% 0%;   /* #000000 Black */
+    --muted: 0 0% 33.3%;                /* #555555 Medium Gray */
+    --muted-foreground: 0 0% 73.3%;     /* #BBBBBB Light Gray */
+    --accent: 180 100% 50%;             /* Cyan, for accent elements */
+    --accent-foreground: 0 0% 0%;       /* Black, for text on accent */
+    --destructive: 0 100% 71%;          /* #FF6B6B Light Red */
+    --destructive-foreground: 0 0% 0%;  /* #000000 Black */
+    --border: 0 0% 33.3%;               /* #555555 Medium Gray */
+    --input: 0 0% 33.3%;                /* #555555 Medium Gray (for input borders) */
+    --ring: 180 100% 50%;               /* #00FFFF Cyan (for focus rings) */
+
+    /* Custom PRD colors - High Contrast versions */
+    --success: 100 100% 45.1%;          /* #39FF14 Neon Green (adjusted from PRD for better contrast on black) */
+    --success-foreground: 0 0% 0%;      /* #000000 Black */
+    --warning: 60 100% 50%;             /* #FFFF00 Yellow (same as primary) */
+    --warning-foreground: 0 0% 0%;      /* #000000 Black */
+
+    /* High Contrast Sidebar variables (can be adjusted further) */
+    --sidebar-background: 0 0% 0%; /* Black */
+    --sidebar-foreground: 0 0% 100%; /* White */
+    --sidebar-primary: 60 100% 50%; /* Yellow */
+    --sidebar-primary-foreground: 0 0% 0%; /* Black */
+    --sidebar-accent: 0 0% 20%; /* Darker Gray for accents */
+    --sidebar-accent-foreground: 0 0% 100%; /* White */
+    --sidebar-border: 0 0% 33.3%; /* Medium Gray */
+    --sidebar-ring: 180 100% 50%; /* Cyan */
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,6 +7,7 @@ import { Brain, Zap, Target, BarChart3, Clock, Users } from "lucide-react";
 import GameInterface from "@/components/GameInterface";
 import Tutorial from "@/components/Tutorial";
 import PerformanceStats from "@/components/PerformanceStats";
+import { HighContrastToggle } from '@/components/ui/HighContrastToggle'; // Added import
 
 const Index = () => {
   const [currentView, setCurrentView] = useState<'landing' | 'tutorial' | 'game' | 'stats'>('landing');
@@ -114,6 +115,9 @@ const Index = () => {
               Quick Tutorial
               <Brain className="ml-2 h-5 w-5" />
             </Button>
+          </div>
+          <div className="flex justify-center mt-6">
+            <HighContrastToggle />
           </div>
         </div>
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+interface SettingsState {
+  isHighContrastMode: boolean;
+  toggleHighContrastMode: () => void;
+  setHighContrastMode: (value: boolean) => void;
+}
+
+// Helper function to apply class to body
+const applyThemeToBody = (isHighContrast: boolean) => {
+  if (typeof window !== 'undefined') { // Ensure runs only on client
+    document.body.classList.toggle('theme-high-contrast', isHighContrast);
+  }
+};
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set, get) => ({
+      isHighContrastMode: false, // Default value
+      toggleHighContrastMode: () => {
+        const newMode = !get().isHighContrastMode;
+        set({ isHighContrastMode: newMode });
+        applyThemeToBody(newMode);
+      },
+      setHighContrastMode: (value) => {
+        set({ isHighContrastMode: value });
+        applyThemeToBody(value);
+      },
+    }),
+    {
+      name: 'app-settings', // Name for localStorage item
+      storage: createJSONStorage(() => localStorage),
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          applyThemeToBody(state.isHighContrastMode);
+        }
+      }
+    }
+  )
+);
+
+// Apply theme on initial client-side load based on persisted settings
+// This helps avoid a flash of default theme if localStorage has a different setting
+// before Zustand fully rehydrates and calls onRehydrateStorage.
+if (typeof window !== 'undefined') {
+  try {
+    const persistedStateString = localStorage.getItem('app-settings');
+    if (persistedStateString) {
+      const persistedState = JSON.parse(persistedStateString);
+      if (persistedState && persistedState.state && typeof persistedState.state.isHighContrastMode === 'boolean') {
+        applyThemeToBody(persistedState.state.isHighContrastMode);
+      }
+    }
+  } catch (e) {
+    console.error("Error applying initial theme from localStorage:", e);
+    // Fallback: ensure default state (no class) if an error occurs or no persisted state
+    applyThemeToBody(false);
+  }
+}


### PR DESCRIPTION
I've added a high-contrast mode to enhance accessibility, aligning with PRD 4.2.2. This feature allows you to switch to a theme with higher contrast between text and background elements.

Key Changes:

1.  **State Management (Zustand)**:
    *   I created a new Zustand store (`src/stores/settingsStore.ts`) to manage `isHighContrastMode`.
    *   State is persisted to `localStorage` ('app-settings') and rehydrated on load.
    *   The store includes logic to toggle a `theme-high-contrast` class on `document.body` when the mode changes.

2.  **CSS Theme Variables**:
    *   I defined CSS variables for a comprehensive set of colors (background, foreground, primary, secondary, card, border, destructive, success, warning, etc.) in `src/index.css`.
    *   I added a `.theme-high-contrast` class definition that overrides these variables with high-contrast values (e.g., black background, white text, yellow/cyan accents).
    *   I updated/verified default theme variables, including custom PRD colors.

3.  **High-Contrast Toggle Component**:
    *   I created `src/components/ui/HighContrastToggle.tsx` which uses a `Switch` component.
    *   This toggle reads from and updates the `isHighContrastMode` state in the Zustand store.

4.  **Integration**:
    *   I placed the `HighContrastToggle` on the main landing page (`src/pages/Index.tsx`) for your access.

The implementation leverages CSS variables for theming, ensuring that shadcn/ui components and Tailwind utility classes correctly adapt to the selected theme. I confirmed good readability and usability across key application pages in high-contrast mode.