### PR TITLE
Feat: Implement Interactive Practice Round after Tutorial

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,10 +8,10 @@ import GameInterface from "@/components/GameInterface";
 import Tutorial from "@/components/Tutorial";
 import PerformanceStats from "@/components/PerformanceStats";
 import { HighContrastToggle } from '@/components/ui/HighContrastToggle';
-import { FontSizeSelector } from '@/components/ui/FontSizeSelector'; // Added import
+import { FontSizeSelector } from '@/components/ui/FontSizeSelector';
 
 const Index = () => {
-  const [currentView, setCurrentView] = useState<'landing' | 'tutorial' | 'game' | 'stats'>('landing');
+  const [currentView, setCurrentView] = useState<'landing' | 'tutorial' | 'practice' | 'game' | 'stats'>('landing');
   const [showQuickStart, setShowQuickStart] = useState(false);
 
   const features = [
@@ -57,11 +57,23 @@ const Index = () => {
   if (currentView === 'tutorial') {
     return <Tutorial
       onComplete={() => {
-        localStorage.setItem('tutorialCompleted', 'true');
-        setCurrentView('game');
+        // Tutorial now leads to practice mode first
+        localStorage.setItem('tutorialCompleted', 'true'); // Still mark tutorial as done
+        setCurrentView('practice');
       }}
       onBack={() => setCurrentView('landing')}
     />;
+  }
+
+  if (currentView === 'practice') {
+    return (
+      <GameInterface
+        isPracticeMode={true}
+        onPracticeComplete={() => setCurrentView('game')} // After practice, go to actual game setup
+        onBack={() => setCurrentView('tutorial')}       // If user backs out of practice, go back to tutorial
+        onViewStats={() => setCurrentView('stats')}     // Prop needed by GameInterface
+      />
+    );
   }
 
   if (currentView === 'game') {


### PR DESCRIPTION
I've added an interactive practice round to the onboarding flow, as per PRD 5.1 & 5.3. This round occurs after you complete the initial tutorial demos and before you start your first full game session.

Key Changes:

1.  **`GameInterface.tsx` Enhancements for Practice Mode**:
    *   I added `isPracticeMode?: boolean` and `onPracticeComplete?: () => void` to `GameInterfaceProps`.
    *   When `isPracticeMode` is true:
        *   Game parameters are fixed: Single Visual, 1-Back, 7 trials.
        *   UI controls on the setup screen (for mode, N-level, trials, duration) are disabled, and the fixed practice parameters are displayed.
        *   Immediate toast notifications are provided after each trial response (or timeout) indicating "Correct Match!", "Missed Match!", "False Alarm!", or "Correct: No match there."
        *   The `endSession` function, when in practice mode, displays a "Practice Complete!" message, calls `onPracticeComplete()`, and bypasses normal session saving, scoring, and adaptive difficulty adjustments.

2.  **Application Flow Integration (`pages/Index.tsx`)**:
    *   I updated the `currentView` state in `Index.tsx` to include a `'practice'` state.
    *   The `onComplete` handler for the `<Tutorial>` component now sets `currentView` to `'practice'`.
    *   I created a new rendering path for `currentView === 'practice'` that instantiates `<GameInterface isPracticeMode={true} ... />`.
    *   The `onPracticeComplete` prop passed to `GameInterface` in practice mode sets `currentView` to `'game'`, transitioning you to the standard game setup screen for a real session.
    *   The `onBack` prop for `GameInterface` in practice mode navigates you back to the `'tutorial'` view.

This feature provides a hands-on experience for new users immediately after the tutorial, allowing you to try the game mechanics with guidance before starting a fully scored session, thereby improving the onboarding process.