### PR TITLE
Refactor: Replace 'lovable' branding with generic placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to your Lovable project
+# Welcome to your This project
 
 ## Project info
 
@@ -8,15 +8,15 @@
 
 There are several ways of editing your application.
 
-**Use Lovable**
+**Use This project platform**
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/4d0eb8d3-b7dc-4adf-82d2-928103e3ab68) and start prompting.
+Simply visit the [This project](YOUR_PROJECT_URL) and start prompting.
 
-Changes made via Lovable will be committed automatically to this repo.
+Changes made via This project platform will be committed automatically to this repo.
 
 **Use your preferred IDE**
 
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in This project platform.
 
 The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
@@ -62,12 +62,12 @@ This project is built with:
 
 ## How can I deploy this project?
 
-Simply open [Lovable](https://lovable.dev/projects/4d0eb8d3-b7dc-4adf-82d2-928103e3ab68) and click on Share -> Publish.
+Simply open [This project platform](YOUR_PROJECT_URL) and click on Share -> Publish.
 
-## Can I connect a custom domain to my Lovable project?
+## Can I connect a custom domain to my This project?
 
 Yes, you can!
 
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+Read more here: [Setting up a custom domain](YOUR_DOCS_URL)

--- a/index.html
+++ b/index.html
@@ -12,11 +12,11 @@
     <meta property="og:title" content="N-Back Brain Training - Enhance Your Working Memory" />
     <meta property="og:description" content="Science-backed cognitive training platform for improving working memory through evidence-based N-Back exercises" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta property="og:image" content="YOUR_IMAGE_URL" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="twitter:site" content="YOUR_TWITTER_HANDLE" />
+    <meta name="twitter:image" content="YOUR_IMAGE_URL" />
     
     <!-- Preload critical resources -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
This commit addresses the issue of removing 'lovable' branding elements from the user-facing parts of the application.

Changes made:
- Modified `index.html`:
    - Replaced `og:image` URL with `YOUR_IMAGE_URL`.
    - Replaced `twitter:site` content with `YOUR_TWITTER_HANDLE`.
    - Replaced `twitter:image` URL with `YOUR_IMAGE_URL`.
- Modified `README.md`:
    - Replaced mentions of "Lovable project" and "Lovable" with generic terms like "This project" or "The project platform".
    - Replaced `lovable.dev` URLs with placeholders like `YOUR_PROJECT_URL` and `YOUR_DOCS_URL`.
- Reviewed `package.json`:
    - The `lovable-tagger` devDependency was kept as it's likely tied to the development platform's workflow and not a direct user-facing branding element.
- Searched `src/` directory:
    - No other occurrences of "lovable" were found in common frontend file types.

These changes make the branding more generic, allowing for easier updates to a new brand identity when available.